### PR TITLE
fix de l'erreur orthographique de l'exo sur les boulce while python

### DIFF
--- a/src/exercises/math/python/pyWhileLoop1Exercise.ts
+++ b/src/exercises/math/python/pyWhileLoop1Exercise.ts
@@ -158,7 +158,7 @@ const generateType17Instruction = (
 ): string => {
   const instruction = `Qu’affichera le programme suivant, si l'utilisateur entre ${a} ?
   \`\`\`
-  a=input("Entrez un entiel naturel non nul.")
+  a=input("Entrez un entier naturel non nul.")
   a=int(a)
   n=1
   while n<=a:


### PR DESCRIPTION
- Correction de la faute de frappe "entiel" dans l'exo python pour les boucle while.